### PR TITLE
Automated unit testing with CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,10 @@
+version: 2.0
+
+jobs:
+    build:
+        docker:
+            -   image: circleci/php:7.2
+        steps:
+            - checkout
+            -   run: composer install -n --prefer-dist
+            -   run: composer test

--- a/composer.json
+++ b/composer.json
@@ -29,5 +29,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^8.2"
+    },
+    "scripts": {
+        "test": "vendor/bin/phpunit tests"
     }
 }


### PR DESCRIPTION
I've added circleCI config to run `composer test` which in turn runs phpunit.

You can use circleCI for free 1,000 build minutes per month.

Log in on https://circleci.com with your github account set up a project for this repository (it's really easy). This config will work with the default project settings, though I'd recommend enabling `Only build pull requests` and `Auto-cancel redundant builds` in the advanced project settings  to save on unnecessary build minutes (https://circleci.com/gh/aeviiq/collection/edit#advanced-settings).