### PR TITLE
Change return type of map function

### DIFF
--- a/src/CollectionInterface.php
+++ b/src/CollectionInterface.php
@@ -52,8 +52,8 @@ interface CollectionInterface extends SortableInterface, \IteratorAggregate, \Ar
     public function remove($element): void;
 
     /**
-     * @psalm-return array<TKey, TValue>
-     * @phpstan-return array<TKey, TValue>
+     * @psalm-return array<TKey, mixed>
+     * @phpstan-return array<TKey, mixed>
      *
      * @return array<string|int, mixed>
      */


### PR DESCRIPTION
The map function is mostly used to convert an array with elements of one type to an array of another type. Example: to convert an array of FooObjects to an array of strings containing the result of `FooObject::getName()`.